### PR TITLE
Adding tests for browser and node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /package-lock.json
 /shrinkwrap.yaml
 /yarn.lock
+test/jszip.js

--- a/package.json
+++ b/package.json
@@ -24,9 +24,21 @@
 	},
 	"homepage": "https://cndtr.io/do-not-zip/",
 	"devDependencies": {
-		"rollup": "*"
+		"browserify": "16.2.0",
+		"jszip": "3.1.5",
+		"rollup": "*",
+		"rollup-plugin-commonjs": "9.1.0",
+		"rollup-plugin-node-resolve": "3.3.0",
+		"tap-colorize": "1.2.0",
+		"tape-run": "4.0.0",
+		"zora": "2.0.1"
 	},
 	"scripts": {
-		"build": "rollup -c"
-	}
+		"build": "rollup -c",
+		"build:jszip": "browserify -s jszip node_modules/jszip/lib/index.js > test/jszip.js",
+		"test:browser": "npm run build:jszip && rollup -c rollup.config.test.js | tape-run | tap-colorize",
+		"test:node": "node test/test.node.js | tap-colorize",
+		"test": "npm run build && npm run test:node && npm run test:browser"
+	},
+	"dependencies": {}
 }

--- a/rollup.config.test.js
+++ b/rollup.config.test.js
@@ -1,0 +1,16 @@
+import commonjs from 'rollup-plugin-commonjs'
+import nodeResolve from 'rollup-plugin-node-resolve'
+
+export default {
+	input: `./test/test.browser.js`,
+	output: [
+		{
+			format: `iife`,
+			name: `tests`,
+		},
+	],
+	plugins: [
+		nodeResolve(),
+		commonjs(),
+	],
+}

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,0 +1,18 @@
+const JSZip = require(`./jszip.js`)
+
+module.exports = {
+	loadJzip(data) {
+		return new JSZip().loadAsync(data)
+	},
+	jzipToEntries(jzip) {
+		const ary = []
+		jzip.forEach((path, file) => ary.push({ path, file }))
+		return ary
+	},
+	entriesToObject(entries) {
+		return entries.reduce((acc, { path, file }) => {
+			acc[path] = file
+			return acc
+		}, Object.create(null))
+	},
+}

--- a/test/test.browser.js
+++ b/test/test.browser.js
@@ -1,0 +1,13 @@
+const test = require(`zora`)
+const doNotZip = require(`../`)
+
+test(`Creates a Blob in the browser`, t => {
+	const outputBlob = doNotZip([
+		{ path: `path/to/file1.txt`, data: `Hello` },
+		{ path: `another/file2.txt`, data: `World` },
+	])
+
+	t.ok(outputBlob instanceof Blob, `output is a Blob`)
+})
+
+require(`./test.everywhere.js`)

--- a/test/test.everywhere.js
+++ b/test/test.everywhere.js
@@ -1,0 +1,20 @@
+const test = require(`zora`)
+const doNotZip = require(`../`)
+const { loadJzip, jzipToEntries, entriesToObject } = require(`./helper.js`)
+
+test(`Creates a zip file that jszip can read`, async t => {
+	const outputBlob = doNotZip([
+		{ path: `path/to/file1.txt`, data: `Hello` },
+		{ path: `another/file2.txt`, data: `World` },
+	])
+	const entries = jzipToEntries(await loadJzip(outputBlob))
+
+	const expectedPaths = [ `path/to/file1.txt`, `another/file2.txt` ]
+
+	t.equal(entries.length, expectedPaths.length)
+
+	const jzipMap = entriesToObject(entries)
+
+	expectedPaths.forEach(expectedPath => expectedPath in jzipMap)
+})
+

--- a/test/test.node.js
+++ b/test/test.node.js
@@ -1,0 +1,13 @@
+const test = require(`zora`)
+const doNotZip = require(`../`)
+
+test(`Creates a Buffer in node`, t => {
+	const outputBlob = doNotZip([
+		{ path: `path/to/file1.txt`, data: `Hello` },
+		{ path: `another/file2.txt`, data: `World` },
+	])
+
+	t.ok(outputBlob instanceof Buffer, `output is a Buffer`)
+})
+
+require(`./test.everywhere.js`)


### PR DESCRIPTION
JSZip's browser/ESM support is tenuous, but it appears to support browserify.

Using JSZip to make assertions added more clutter than I would have liked, but it seems like a reasonable way to get assertions on every platform.