### PR TITLE
Fix a "Maximum call stack size exceeded" crash

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,8 @@ export default files => {
 		const pathBytes = toBytes(path);
 		const commonHeader = [0x0A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, ...int(crc32(dataBytes), 4), ...int(dataBytes.length, 4), ...int(dataBytes.length, 4), ...int(pathBytes.length, 2), 0x00, 0x00];
 		centralDirectory.push(0x50, 0x4B, 0x01, 0x02, 0x14, 0x00, ...commonHeader, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, ...int(fileData.length, 4), ...pathBytes);
-		fileData.push(0x50, 0x4B, 0x03, 0x04, ...commonHeader, ...pathBytes, ...dataBytes);
+		fileData.push(0x50, 0x4B, 0x03, 0x04, ...commonHeader, ...pathBytes);
+		dataBytes.forEach(byte => fileData.push(byte))
 	}
 	const bytes = [...fileData, ...centralDirectory, 0x50, 0x4B, 0x05, 0x06, 0x00, 0x00, 0x00, 0x00, ...int(files.length, 2), ...int(files.length, 2), ...int(centralDirectory.length, 4), ...int(fileData.length, 4), 0x00, 0x00];
 	if (typeof Blob !== 'undefined' && typeof Uint8Array !== 'undefined') {


### PR DESCRIPTION
node.js was throwing "Maximum call stack size exceeded" on line 40 here with input data above a certain size.  Dropping the spread operator avoids the error for large arrays/iterables.