### PR TITLE
Fix lack of encoding to UTF-8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "do-not-zip",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Do not zip. Just store.",
 	"keywords": [
 		"browser",

--- a/src/toArray.js
+++ b/src/toArray.js
@@ -9,7 +9,7 @@ const int = (n, length) => {
 	return out;
 };
 
-const toBytes = data => typeof data === 'string' ? [...data].map(char => char.charCodeAt(0)) : data;
+const toBytes = data => typeof data === 'string' ? new TextEncoder().encode(data) : data;
 
 export default files => {
 	let fileData = [];

--- a/test/helper.js
+++ b/test/helper.js
@@ -6,12 +6,12 @@ module.exports = {
 	},
 	jzipToEntries(jzip) {
 		const ary = []
-		jzip.forEach((path, file) => ary.push({ path, file }))
-		return ary
+		jzip.forEach((path, file) => ary.push(file.async("string").then((str) => ({ path, str }))))
+		return Promise.all(ary)
 	},
 	entriesToObject(entries) {
-		return entries.reduce((acc, { path, file }) => {
-			acc[path] = file
+		return entries.reduce((acc, { path, str }) => {
+			acc[path] = str
 			return acc
 		}, Object.create(null))
 	},

--- a/test/test.everywhere.js
+++ b/test/test.everywhere.js
@@ -3,17 +3,28 @@ const doNotZip = require(`../`)
 const { loadJzip, jzipToEntries, entriesToObject } = require(`./helper.js`)
 
 test(`Creates a zip file that jszip can read`, async t => {
-	const outputBlob = doNotZip.toAuto([
-		{ path: `path/to/file1.txt`, data: `Hello` },
-		{ path: `another/file2.txt`, data: `World` },
-	])
-	const entries = jzipToEntries(await loadJzip(outputBlob))
+    const data = [
+        { path: `path/to/file1.txt`, data: `Hello` },
+        { path: `another/file2.txt`, data: `World` },
+        { path: `cyrillic_text.txt`, data: `абвгде` },
+        { path: `surrogateChar.txt`, data: `\uD800\uDC00` },
+    ];
+	const outputBlob = doNotZip.toAuto(data)
+	const entries = await jzipToEntries(await loadJzip(outputBlob))
 
-	const expectedPaths = [ `path/to/file1.txt`, `another/file2.txt` ]
-
-	t.equal(entries.length, expectedPaths.length)
+	t.equal(entries.length, data.length)
 
 	const jzipMap = entriesToObject(entries)
 
-	expectedPaths.forEach(expectedPath => t.ok(expectedPath in jzipMap))
+    t.test(`All the files presented in the archive`, t => {
+        data.forEach(({ path, data }) => {
+            t.ok(path in jzipMap);
+        })
+    })
+
+    t.test(`All the contents are the same`, t => {
+        data.forEach(({ path, data }) => {
+            t.equal(data, jzipMap[path]);
+        })
+    })
 })


### PR DESCRIPTION
Mostly it's PR to fix https://github.com/sveltejs/svelte/issues/3323
I think the issue should be fixed here because this library generates archives with content that doesn't match the one passed to the input.

The first thing is that the library doesn't convert Unicode char codes to UTF-8's. 
The second is that for surrogate characters, the lib is ignoring the second character of the pair. 
For both cases, added tests with checking of the unzipped content.

Here are logs of new tests without encoding the input text:
```
TAP version 13
# Creates a zip file that jszip can read
ok 1 - should be equal
# All the files presented in the archive
ok 2 - should be truthy
ok 3 - should be truthy
ok 4 - should be truthy
ok 5 - should be truthy
# All the contents are the same
ok 6 - should be equal
ok 7 - should be equal
not ok 8 - should be equal
  ---
  expected: "012345"
  actual: "абвгде"
  at: " data.forEach (http://localhost:46487/bundle.js:18833:16)"
  operator: "equal"
  ...
not ok 9 - should be equal
  ---
  expected: "\u0000"
  actual: "𐀀"
  at: " data.forEach (http://localhost:46487/bundle.js:18833:16)"
  operator: "equal"
  ...
# Creates a Blob in the browser
ok 10 - output is a Blob
1..10
# failed 2 of 10 tests
```

Test 8 checks encoding of characters above 0x7F and the first letters of the Cyrillic alphabet were turned to numbers XD
Test 9 checks encoding of surrogate characters (used to display symbols above 0xFFFF) - the sample symbol was turned to \0.